### PR TITLE
feat(cli): allow watching eleventy files

### DIFF
--- a/packages/cli/src/start/cli.js
+++ b/packages/cli/src/start/cli.js
@@ -5,45 +5,14 @@
 /* eslint-disable no-console, no-param-reassign */
 const { createConfig, startServer } = require('es-dev-server');
 const path = require('path');
-const fs = require('fs');
 const Eleventy = require('@11ty/eleventy');
 
 const readCommandLineArgs = require('./readCommandLineArgs');
-
-function getFileWithLastUrlDir(url, absRootDir) {
-  const endIndex = url.length - 1;
-  const startIndex = url.lastIndexOf('/', endIndex - 1);
-  const name = url.substring(startIndex + 1, endIndex);
-  const pathTo = url.substring(0, startIndex);
-  const relPath = path.join(pathTo, `${name}.md`);
-  const possibleFile = path.join(absRootDir, relPath);
-  if (fs.existsSync(possibleFile)) {
-    return relPath;
-  }
-  return '';
-}
-
-async function eleventyRender(elev, relPath, serverPath) {
-  // const serverPath = context.path;
-
-  let body = 'eleventyRender: File not found';
-  elev.config.filters['hook-for-rocket'] = (content, outputPath, inputPath) => {
-    const compare = path.join(relPath, inputPath);
-    if (serverPath === `/${compare}`) {
-      body = content;
-    }
-    return content;
-  };
-  await elev.write();
-  return body
-    .replace(/href="\//g, 'href="/packages/cli/demo/docs/')
-    .replace(/src="\//g, 'src="/packages/cli/demo/docs/');
-}
+const eleventyPlugin = require('./eleventyPlugin');
 
 async function run() {
   const config = /** @type {ServerConfig & { files: string[], configDir: string }} */ (readCommandLineArgs());
   const absRootDir = path.resolve(config.esDevServer.rootDir);
-  const relPath = path.relative(absRootDir, process.cwd());
 
   const elev = new Eleventy('./demo/docs', './__site');
   elev.setConfigPathOverride('./src/shared/.eleventy.js');
@@ -57,33 +26,7 @@ async function run() {
     watch: true,
     // open: './docs/README.md',
     // open: './packages/cli/demo/docs/README.md',
-    plugins: [
-      {
-        async serve(ctx) {
-          let usePath = ctx.path;
-          if (ctx.path.endsWith('index.html')) {
-            usePath = ctx.path.replace('index.html', 'index.md');
-          } else if (ctx.path.endsWith('.html')) {
-            usePath = ctx.path.replace('.html', '.md');
-          } else if (ctx.path.endsWith('/')) {
-            const fileForUrl = getFileWithLastUrlDir(ctx.path, absRootDir);
-            if (fileForUrl) {
-              usePath = fileForUrl;
-            } else {
-              usePath += 'index.md';
-            }
-          }
-          if (usePath.endsWith('md')) {
-            const newBody = await eleventyRender(elev, relPath, usePath);
-            return {
-              body: newBody,
-              type: 'html',
-            };
-          }
-          return undefined;
-        },
-      },
-    ],
+    plugins: [eleventyPlugin({ elev, absRootDir })],
   };
 
   startServer(createConfig(config.esDevServer));

--- a/packages/cli/src/start/eleventyPlugin.js
+++ b/packages/cli/src/start/eleventyPlugin.js
@@ -1,0 +1,92 @@
+/* eslint-disable no-param-reassign */
+const fs = require('fs').promises;
+const path = require('path');
+
+const REGEXP_TO_FILE_PATH = new RegExp('/', 'g');
+
+function toFilePath(browserPath) {
+  return browserPath.replace(REGEXP_TO_FILE_PATH, path.sep);
+}
+
+async function getFileWithLastUrlDir(browserPath, absRootDir) {
+  const endIndex = browserPath.length - 1;
+  const startIndex = browserPath.lastIndexOf('/', endIndex - 1);
+  const name = browserPath.substring(startIndex + 1, endIndex);
+  const pathTo = browserPath.substring(0, startIndex);
+  const browserPathWithFilename = path.join(pathTo, `${name}.md`);
+  const potentialFilePath = path.join(absRootDir, toFilePath(browserPathWithFilename));
+
+  try {
+    await fs.access(potentialFilePath);
+    return potentialFilePath;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+async function getEleventyRenderedFile(elev, absRootDir, absFilePath) {
+  let body = 'eleventyRender: File not found';
+  elev.config.filters['hook-for-rocket'] = (content, outputPath, inputPath) => {
+    const currentAbsFilePath = path.join(process.cwd(), inputPath);
+
+    // check if this is the file we're looking for
+    if (currentAbsFilePath === absFilePath) {
+      body = content;
+    }
+    return content;
+  };
+
+  await elev.write();
+
+  // TODO: Make this work outside this repository
+  return body
+    .replace(/href="\//g, 'href="/packages/cli/demo/docs/')
+    .replace(/src="\//g, 'src="/packages/cli/demo/docs/');
+}
+
+function eleventyPlugin({ absRootDir, elev }) {
+  /** @type {import('chokidar').FSWatcher} */
+  let fileWatcher;
+
+  return {
+    serverStart(args) {
+      ({ fileWatcher } = args);
+    },
+
+    async serve(ctx) {
+      let absFilePath;
+
+      if (ctx.path.endsWith('/')) {
+        // for urls ending with / we need to match eleventy's URL rewriting logic
+        const filePathForUrl = await getFileWithLastUrlDir(ctx.path, absRootDir);
+
+        if (filePathForUrl) {
+          // URL: /foo/bar/, eleventy: /foo/bar.md
+          absFilePath = filePathForUrl;
+        } else {
+          // URL: /foo/bar/, eleventy: /foo/bar/index.md
+          absFilePath = path.join(absRootDir, toFilePath(ctx.path), 'index.md');
+        }
+      } else if (['.html', '.md'].some(ext => ctx.path.endsWith(ext))) {
+        // we handle urls that end with .html or .md
+        // URL: /foo/bar/index.html, eleventy: /foo/bar/index.md
+        // URL: /foo/bar/foo.md, eleventy: /foo/bar/foo.md
+        const browserPath = ctx.path.replace('.html', '.md');
+        absFilePath = path.join(absRootDir, toFilePath(browserPath));
+      } else {
+        // we don't handle urls that don't end with /, .md or .html
+        return undefined;
+      }
+
+      const newBody = await getEleventyRenderedFile(elev, absRootDir, absFilePath);
+      if (!newBody) {
+        return undefined;
+      }
+
+      fileWatcher.add(absFilePath);
+      return { body: newBody, type: 'html' };
+    },
+  };
+}
+
+module.exports = eleventyPlugin;


### PR DESCRIPTION
This adds watch mode for eleventy files. For this to work I had to get the absolute file path of the served files, this required some refactoring of the es-dev-server plugin. I also took the opportunity to make sure paths are properly converted from URL to file path for windows.

As far as I can tell all the functionalities still work, but please double check :)