### PR TITLE
fix(eleventy-rocket-nav): allow to process bigger (up to 256kB) html …

### DIFF
--- a/.changeset/lovely-mirrors-reply.md
+++ b/.changeset/lovely-mirrors-reply.md
@@ -1,0 +1,5 @@
+---
+'@d4kmor/eleventy-rocket-nav': patch
+---
+
+Wasm needs to get enough memory so it can access bigger html files. Now up to 256kB.

--- a/packages/eleventy-rocket-nav/eleventy-rocket-nav.js
+++ b/packages/eleventy-rocket-nav/eleventy-rocket-nav.js
@@ -11,7 +11,7 @@ const saxWasmBuffer = fs.readFileSync(saxPath);
 // Instantiate
 const parser = new SAXParser(
   SaxEventType.Attribute | SaxEventType.OpenTag | SaxEventType.Text | SaxEventType.CloseTag,
-  { highWaterMark: 64 * 1024 }, // 64k chunks
+  { highWaterMark: 256 * 1024 }, // 256k chunks
 );
 parser.prepareWasm(saxWasmBuffer);
 


### PR DESCRIPTION
What I did:

- raise memory for wasm so it can process bigger html files
- closes https://github.com/daKmoR/rocket/issues/41