### PR TITLE
fix(search): theming, trucate text, 10 results, icons to artifact

### DIFF
--- a/.changeset/itchy-eggs-press.md
+++ b/.changeset/itchy-eggs-press.md
@@ -1,0 +1,9 @@
+---
+'@d4kmor/search': patch
+---
+
+applied following fixies
+- expose some css theming variables
+- truncate text also when many terms are found
+- show only a max of 10 results for the frontend
+- add icons to npm artifact

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -25,6 +25,7 @@
     "*.js",
     "dist",
     "dist-types",
+    "assets",
     "src",
     "theme"
   ],

--- a/packages/search/src/RocketSearch.js
+++ b/packages/search/src/RocketSearch.js
@@ -39,6 +39,7 @@ export class RocketSearch extends ScopedElementsMixin(LitElement) {
       jsonUrl: { type: String, attribute: 'json-url' },
       search: { type: String },
       results: { type: Array },
+      maxResults: { type: Number, attribute: 'max-results' },
     };
   }
 
@@ -53,6 +54,7 @@ export class RocketSearch extends ScopedElementsMixin(LitElement) {
     super();
     this.jsonUrl = '';
     this.search = '';
+    this.maxResults = 10;
     /**
      * @type {RocketSearchResult[]}
      */
@@ -96,7 +98,9 @@ export class RocketSearch extends ScopedElementsMixin(LitElement) {
   /** @param {import('lit-element').PropertyValues } changedProperties */
   update(changedProperties) {
     if (this.miniSearch && changedProperties.has('search')) {
-      this.results = /** @type {RocketSearchResult[]} */ (this.miniSearch.search(this.search));
+      this.results = /** @type {RocketSearchResult[]} */ (this.miniSearch.search(
+        this.search,
+      )).slice(0, this.maxResults);
     }
 
     super.update(changedProperties);

--- a/packages/search/src/RocketSearchCombobox.js
+++ b/packages/search/src/RocketSearchCombobox.js
@@ -7,10 +7,6 @@ export class RocketSearchCombobox extends LionCombobox {
     return [
       super.styles,
       css`
-        :host {
-          background: #fff;
-        }
-
         ::slotted([slot='label']) {
           display: none;
         }
@@ -27,6 +23,7 @@ export class RocketSearchCombobox extends LionCombobox {
           padding: 0;
           font: inherit;
           cursor: pointer;
+          fill: var(--rocket-search-fill-color, #000);
         }
 
         ::slotted([slot='prefix'][arrow-left]) {
@@ -36,6 +33,7 @@ export class RocketSearchCombobox extends LionCombobox {
 
         ::slotted([slot='listbox']) {
           max-height: calc(100vh - 70px);
+          background: var(--rocket-search-background-color, #fff);
         }
 
         .input-group__container {
@@ -62,8 +60,8 @@ export class RocketSearchCombobox extends LionCombobox {
           bottom: 0;
           left: 0;
           right: 0;
-          background: #fff;
           height: 100vh;
+          background: var(--rocket-search-background-color, #fff);
         }
 
         :host([show-input]) ::slotted([slot='prefix'][arrow-left]) {
@@ -93,9 +91,6 @@ export class RocketSearchCombobox extends LionCombobox {
             position: static !important;
             width: auto !important;
             transform: none !important;
-
-            /* height: 300px;
-            overflow: scroll; */
           }
         }
 
@@ -111,7 +106,7 @@ export class RocketSearchCombobox extends LionCombobox {
 
           .input-group__container {
             position: relative;
-            background: #fff;
+            background: var(--rocket-search-background-color, #fff);
             display: flex;
             border: 1px solid #dfe1e5;
             box-shadow: none;

--- a/packages/search/src/RocketSearchOption.js
+++ b/packages/search/src/RocketSearchOption.js
@@ -43,20 +43,34 @@ export class RocketSearchOption extends LinkMixin(LionOption) {
 
   static get styles() {
     return [
-      super.styles,
       css`
+        :host([hidden]) {
+          display: none;
+        }
+
+        :host(:hover) {
+          background-color: var(--rocket-search-hover-background-color, #eee);
+        }
+        :host([active]) {
+          background-color: var(--rocket-search-hover-background-color, #eee);
+        }
+        /* :host:hover,
+        :host([active]) {
+          background: #eee !important;
+        } */
+
+        :host([disabled]) {
+          color: #adadad;
+        }
+
         :host {
+          display: block;
+          cursor: default;
           position: relative;
           padding: 12px 10px;
           display: flex;
           align-items: center;
-          background: none;
           font-weight: normal;
-        }
-
-        :host:hover,
-        :host([active]) {
-          background: #eee !important;
         }
 
         .icon {
@@ -68,11 +82,14 @@ export class RocketSearchOption extends LinkMixin(LionOption) {
 
         .title {
           margin-bottom: 4px;
-          color: #000;
         }
 
         .text {
           font-size: 14px;
+        }
+
+        strong {
+          color: var(--rocket-search-highlight-color, #6c63ff);
         }
 
         @media screen and (min-width: 1024px) {

--- a/packages/search/src/utils-shared.js
+++ b/packages/search/src/utils-shared.js
@@ -1,3 +1,7 @@
+/**
+ * @param {string} title
+ * @param {string} headline
+ */
 export function joinTitleHeadline(title, headline) {
   if (title === headline) {
     return title;
@@ -5,6 +9,9 @@ export function joinTitleHeadline(title, headline) {
   return `${title} > ${headline}`;
 }
 
+/**
+ * @param {string} term
+ */
 function defaultHighlight(term) {
   return `<strong>${term}</strong>`;
 }
@@ -35,6 +42,8 @@ export function highlightSearchTerms({
   let newText = text;
   let searchText = newText.toLowerCase();
   let extraLength = 0;
+  let truncateStart = 0;
+
   let firstFoundIndex;
   for (const term of terms) {
     let offset = 0;
@@ -50,17 +59,15 @@ export function highlightSearchTerms({
         newText = [newText.slice(0, startIndex), highlightedTerm, newText.slice(endIndex)].join('');
         searchText = newText.toLowerCase();
         offset = startIndex + highlightedTerm.length;
-        extraLength += highlightedTerm.length - addForEnd;
         if (firstFoundIndex === undefined || startIndex < firstFoundIndex) {
           firstFoundIndex = startIndex;
+          truncateStart = firstFoundIndex - before > 0 ? firstFoundIndex - before : 0;
+        }
+        if (startIndex - truncateStart - extraLength < length) {
+          extraLength += highlightedTerm.length - addForEnd;
         }
       }
     } while (startIndex !== -1);
-  }
-
-  let truncateStart = 0;
-  if (firstFoundIndex !== undefined) {
-    truncateStart = firstFoundIndex - before > 0 ? firstFoundIndex - before : 0;
   }
 
   return newText.substr(truncateStart, length + extraLength);

--- a/packages/search/test-web/utils-shared.test.js
+++ b/packages/search/test-web/utils-shared.test.js
@@ -64,7 +64,7 @@ describe('utils-shared: highlightSearchTerms', () => {
     expect(highlighted).to.equal('You should <strong>lau</strong>nch that product.');
   });
 
-  it('truncates the text to 100 characters by default', async () => {
+  it('truncates the text to 100 characters + highlight code', async () => {
     const highlighted = highlightSearchTerms({
       search: 'launch',
       terms: ['launch'],
@@ -75,6 +75,20 @@ describe('utils-shared: highlightSearchTerms', () => {
       ].join(' '),
     });
     expect(highlighted.length).to.equal(117); // 100 + 17 (the length of "<strong></strong>" to highlight the term)
+  });
+
+  it('truncates the text to 100 characters + highlight code only for the turncated text', async () => {
+    const highlighted = highlightSearchTerms({
+      search: 'l',
+      terms: ['l'],
+      text: [
+        'What lovely lego launch product you have laying around this lake of lonely lovers. Would be a shame if it would be lost.',
+      ].join(' '),
+    });
+    expect(highlighted.length).to.equal(270); // 100 + 10*17 (the length of "<strong></strong>" to highlight the term)
+    expect(highlighted).to.equal(
+      'What <strong>l</strong>ove<strong>l</strong>y <strong>l</strong>ego <strong>l</strong>aunch product you have <strong>l</strong>aying around this <strong>l</strong>ake of <strong>l</strong>one<strong>l</strong>y <strong>l</strong>overs. Wou<strong>l</strong>d be a shame ',
+    );
   });
 
   it('truncates the text around to the first found term', async () => {


### PR DESCRIPTION
## What I did

- expose some css theming variables
- truncate text also when many terms are found
- show only a max of 10 results for the frontend
- add icons to npm artifact