### PR TITLE
fix: semantic HTML in home

### DIFF
--- a/packages/launch/theme/_includes/home.njk
+++ b/packages/launch/theme/_includes/home.njk
@@ -37,22 +37,22 @@
 
     <p class="page-slogan">{{slogan}}</p>
 
-    <div class="call-to-action-list">
+    <div class="call-to-action-list" role="list">
       {% for callToAction in callToActionItems %}
-        <a class="call-to-action" href="{{ callToAction.href | url }}">{{ callToAction.text | safe }}</a>
+        <a class="call-to-action" href="{{ callToAction.href | url }}" role="listitem">{{ callToAction.text | safe }}</a>
       {% endfor %}
     </div>
 
     <h2 class="reason-header">{{ reasonHeader }}</h2>
 
-    <div class="reasons">
+    <section class="reasons">
       {% for reason in reasons %}
-        <div>
+        <article>
           <h3>{{ reason.header }}</h3>
           {{ reason.text | safe }}
-        </div>
+        </article>
       {% endfor %}
-    </div>
+    </section>
 
     {{ content.html | safe }}
     {% include 'partials/previousNext.njk' %}


### PR DESCRIPTION
## What I did

1. Change some elements in the Homepage template to use semantic HTML instead of div
2. Add list and listitem roles to CTA container and links, respectively. 

Note to reviewers: please verify that no CSS changes are needed