### PR TITLE
feat(rocket-search): caret-color css var

### DIFF
--- a/packages/search/src/RocketSearch.js
+++ b/packages/search/src/RocketSearch.js
@@ -141,6 +141,10 @@ export class RocketSearch extends ScopedElementsMixin(LitElement) {
       :host {
         display: block;
       }
+
+      ::slotted(input.form-control) {
+        caret-color: var(--rocket-search-caret-color, initial);
+      }
     `;
   }
 }


### PR DESCRIPTION
## What I did

1. added a css var `--rocket-search-caret-color` to `<rocket-search>`. This allows the user to configure the caret color, which is too dim in dark mode.

<img width="1278" alt="Screen Shot 2020-12-13 at 10 15 41" src="https://user-images.githubusercontent.com/1466420/102006752-37442400-3d2c-11eb-8cf3-44f2c34deaef.png">

