### PR TITLE
fix(launch): a11y for 'anchor' links

### DIFF
--- a/packages/launch/theme/_assets/markdown.css
+++ b/packages/launch/theme/_assets/markdown.css
@@ -41,6 +41,12 @@
   text-decoration: none;
 }
 
+.markdown-body h1:focus-within .anchor .octicon-link,
+.markdown-body h2:focus-within .anchor .octicon-link,
+.markdown-body h3:focus-within .anchor .octicon-link,
+.markdown-body h4:focus-within .anchor .octicon-link,
+.markdown-body h5:focus-within .anchor .octicon-link,
+.markdown-body h6:focus-within .anchor .octicon-link,
 .markdown-body h1:hover .anchor .octicon-link,
 .markdown-body h2:hover .anchor .octicon-link,
 .markdown-body h3:hover .anchor .octicon-link,


### PR DESCRIPTION
add :focus-within to visible rules

## What I did

1. add :focus-within to visibility rule for 'anchor' links
Fixes #141 
