### PR TITLE
fix(cli): allow users to use eleventy events

### DIFF
--- a/packages/cli/src/shared/eleventyConfigEmpty.js
+++ b/packages/cli/src/shared/eleventyConfigEmpty.js
@@ -46,4 +46,5 @@ export const eleventyConfigEmpty = {
   setQuietMode: () => {},
   addExtension: () => {},
   addDataExtension: () => {},
+  on: () => {},
 };


### PR DESCRIPTION
## What I did

1. add fake `on` method to the fake config

Perhaps, though, a real eleventy config should be instantiated, and it's members iterated over to create this object, so that additions in future versions of eleventy don't break rocket
