### PR TITLE
fix: allow inputDir configuration, and update unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "setup:ts-configs": "node scripts/generate-ts-configs.mjs",
     "start": "node packages/cli/src/cli.js start",
     "test": "yarn test:node && yarn test:web",
-    "test:node": "mocha \"packages/*/test-node/**/*.test.{ts,js,mjs,cjs}\" --reporter dot --exit --retries 3",
+    "test:node": "mocha \"packages/*/test-node/**/*.test.{ts,js,mjs,cjs}\" --reporter dot --exit --retries 3 --timeout 10000",
     "test:web": "web-test-runner",
     "types": "run-s types:clear types:copy types:build",
     "types:build": "tsc --build",

--- a/packages/cli/src/normalizeConfig.js
+++ b/packages/cli/src/normalizeConfig.js
@@ -148,7 +148,7 @@ export async function normalizeConfig(inConfig) {
 
     configDir: config.configDir,
     _configDirCwdRelative,
-    inputDir,
+    inputDir: config.inputDir ? config.inputDir : inputDir,
     _inputDirConfigDirRelative,
   };
 }

--- a/packages/cli/test-node/normalizeConfig.test.js
+++ b/packages/cli/test-node/normalizeConfig.test.js
@@ -62,7 +62,10 @@ describe('normalizeConfig', () => {
       devServer: {
         more: 'settings',
       },
+      inputDir: 'my-docs',
     });
+
+    expect(config.inputDir).to.equal('my-docs');
 
     expect(cleanup(config)).to.deep.equal({
       command: 'help',


### PR DESCRIPTION
## What I did

1. Wrote test demonstrating that normalizeConfig failed to update inputDir from rocket.config.js
2. Fixed normalizeConfig, so that the test passes.
3. User tested with { inputDir = "doc-dir/my-docs" }, including live updates. Success!
