### PR TITLE
chore: cut a release

### DIFF
--- a/.changeset/lovely-shirts-invite.md
+++ b/.changeset/lovely-shirts-invite.md
@@ -1,0 +1,9 @@
+---
+'@mdjs/core': minor
+---
+
+Use new dependency [plugins-manager](https://www.npmjs.com/package/plugins-manager) to add, remove or adjust plugins.
+
+Removals:
+- Removed own add plugin helper again
+- Removed deprecated export of `mdjsProcessPlugins` please us `setupPlugins` option instead

--- a/.changeset/mean-birds-move.md
+++ b/.changeset/mean-birds-move.md
@@ -1,0 +1,20 @@
+---
+'@d4kmor/eleventy-plugin-mdjs-unified': minor
+'@d4kmor/blog': minor
+'@d4kmor/building-rollup': minor
+'@d4kmor/cli': minor
+'@d4kmor/core': minor
+'@d4kmor/drawer': minor
+'@d4kmor/eleventy-rocket-nav': minor
+'@d4kmor/launch': minor
+'@d4kmor/navigation': minor
+'@d4kmor/search': minor
+---
+
+Prepare release before moving npm scope and repo. 
+
+- Have building-rollup as a dedicated package
+- Serve dev output as server root
+- Rename `themes` to `presets`
+- Move eleventy settings in to dedicated eleventy plugins
+- Introduce `setup-*` function which can be used to add, remove and adjust plugins for all systems

--- a/.changeset/proud-turkeys-guess.md
+++ b/.changeset/proud-turkeys-guess.md
@@ -1,0 +1,5 @@
+---
+'plugins-manager': minor
+---
+
+First initial release

--- a/.changeset/quick-cameras-greet.md
+++ b/.changeset/quick-cameras-greet.md
@@ -1,0 +1,5 @@
+---
+'@d4kmor/building-rollup': minor
+---
+
+First initial release

--- a/packages/eleventy-plugin-mdjs-unified/src/eleventy-plugin-mdjs-unified.js
+++ b/packages/eleventy-plugin-mdjs-unified/src/eleventy-plugin-mdjs-unified.js
@@ -32,22 +32,24 @@ function adjustLinks(pluginOptions) {
   const elementVisitor = node => {
     if (node.tagName === 'a') {
       const fullHref = node.properties && node.properties.href ? node.properties.href : undefined;
-      const [href, anchor] = fullHref.split('#');
-      const suffix = anchor ? `#${anchor}` : '';
-      const { inputPath } = pluginOptions.page;
+      if (fullHref) {
+        const [href, anchor] = fullHref.split('#');
+        const suffix = anchor ? `#${anchor}` : '';
+        const { inputPath } = pluginOptions.page;
 
-      if (isInternalLink(href) && href.endsWith('.md')) {
-        if (href.endsWith('index.md')) {
-          node.properties.href = `${href.substring(0, href.lastIndexOf('/') + 1)}${suffix}`;
-        } else {
-          node.properties.href = `${href.substring(0, href.length - 3)}/${suffix}`;
-        }
-
-        if (inputPath.endsWith('.md')) {
-          if (inputPath.endsWith('index.md')) {
-            // nothing
+        if (isInternalLink(href) && href.endsWith('.md')) {
+          if (href.endsWith('index.md')) {
+            node.properties.href = `${href.substring(0, href.lastIndexOf('/') + 1)}${suffix}`;
           } else {
-            node.properties.href = `../${node.properties.href}`;
+            node.properties.href = `${href.substring(0, href.length - 3)}/${suffix}`;
+          }
+
+          if (inputPath.endsWith('.md')) {
+            if (inputPath.endsWith('index.md')) {
+              // nothing
+            } else {
+              node.properties.href = `../${node.properties.href}`;
+            }
           }
         }
       }

--- a/packages/mdjs-core/package.json
+++ b/packages/mdjs-core/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/open-wc/open-wc.git",
+    "url": "https://github.com/daKmoR/rocket.git",
     "directory": "packages/mdjs-core"
   },
   "author": "Modern Web <hello@modern-web.dev> (https://modern-web.dev/)",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,9 +26,6 @@
       "path": "./packages/eleventy-rocket-nav/tsconfig.json"
     },
     {
-      "path": "./packages/cli/tsconfig.json"
-    },
-    {
       "path": "./packages/drawer/tsconfig.json"
     },
     {

--- a/workspace-packages.mjs
+++ b/workspace-packages.mjs
@@ -1,5 +1,5 @@
 const packages = [
-  { name: 'cli', type: 'js', environment: 'node-esm' },
+  // { name: 'cli', type: 'js', environment: 'node-esm' },
   { name: 'plugins-manager', type: 'js', environment: 'node-esm' },
   { name: 'core', type: 'js', environment: 'node' },
   { name: 'eleventy-plugin-mdjs-unified', type: 'js', environment: 'node' },


### PR DESCRIPTION
## What I did

1. Prepare a release for almost all packages
2. Quite some changes 😅

- Have building-rollup as a dedicated package
- Serve dev output as server root
- Rename `themes` to `presets`
- Move eleventy settings in to dedicated eleventy plugins
- Introduce `setup-*` function which can be used to add, remove and adjust plugins for all systems


PS: disable typescript for the `cli` package for now (as it does not want to read the plugins-manager types 🤷‍♂️ )