### PR TITLE
fix(drawer): reset translation on teardown overlay controller

### DIFF
--- a/.changeset/soft-starfishes-remember.md
+++ b/.changeset/soft-starfishes-remember.md
@@ -1,0 +1,5 @@
+---
+'@d4kmor/drawer': patch
+---
+
+reset translation on teardown overlay controller

--- a/packages/drawer/src/RocketDrawer.js
+++ b/packages/drawer/src/RocketDrawer.js
@@ -64,6 +64,11 @@ export class RocketDrawer extends OverlayMixin(LitElement) {
     }
   }
 
+  _teardownOverlayCtrl() {
+    super._teardownOverlayCtrl();
+    this._overlayCtrl.contentNode.style.transform = 'translateX(0)';
+  }
+
   /** @param {import('lit-element').PropertyValues } changedProperties */
   updated(changedProperties) {
     super.updated(changedProperties);


### PR DESCRIPTION
## What I did

1. Fix translation of drawer when the window is resized

The issue could be seen on a iPad pro for example when rotating the tablet or when manually resizing the window

![OyruN9WgjT](https://user-images.githubusercontent.com/9367152/103809480-8e859d80-5027-11eb-8696-0c164a0bb850.gif)

